### PR TITLE
Agregando codificación a texto a exportar

### DIFF
--- a/spanish/Web Scraping con Beautiful Soup.py
+++ b/spanish/Web Scraping con Beautiful Soup.py
@@ -15,5 +15,5 @@ title = box.find('h1').get_text()
 transcript = box.find('div', class_='full-script').get_text(strip=True, separator=' ')
 
 # Exportar data en un archivo txt con el nombre de la variable titulo (title)
-with open(f'{title}.txt', 'w') as file:
+with open(f'{title}.txt', 'w', encoding='utf-8') as file:
     file.write(transcript)


### PR DESCRIPTION
Se agrega el encoding='utf-8' para que no arroje error UnicodeEncodeError: 'charmap' codec can't encode character '\ufb02' in position 32153: character maps to <undefined>